### PR TITLE
 changes to allow Supplementer to be called from ApplicationSObjectDo…

### DIFF
--- a/sfdx-source/core/main/classes/framework-application-factory/ApplicationSObjectDomain.cls
+++ b/sfdx-source/core/main/classes/framework-application-factory/ApplicationSObjectDomain.cls
@@ -45,6 +45,7 @@ public abstract class ApplicationSObjectDomain
     {
         super.handleBeforeInsert();
         this.getDomainProcessCoordinator().processDomainLogicInjections( DomainProcessConstants.PROCESS_CONTEXT.TriggerExecution, System.TriggerOperation.Before_Insert );
+        if (System.Test.isRunningTest()) TestDataSupplementer.supplement(records);
     }
 
     public virtual override void handleBeforeUpdate(Map<Id,SObject> existingRecords)

--- a/sfdx-source/core/main/classes/framework-test-data-supplementer/TestDataSupplementer.cls
+++ b/sfdx-source/core/main/classes/framework-test-data-supplementer/TestDataSupplementer.cls
@@ -56,9 +56,14 @@ public class TestDataSupplementer
     {
         if (sobjectList != null && !sobjectList.isEmpty())
         {
-            for (ITestDataSupplement supplementer : supplementerMap.get(sobjectList.getSObjectType()))
-            {
-                supplementer.supplement(sobjectList);
+            //now that supplement is called from ApplicationSObjectDomain
+            //a supplement might not exist for every object type would result in an eror
+            //check that ObjectType exists in the map before doing the look
+            If (supplementerMap.containsKey(sobjectList.getSObjectType())) {
+                for (ITestDataSupplement supplementer : supplementerMap.get(sobjectList.getSObjectType()))
+                {
+                    supplementer.supplement(sobjectList);
+                }
             }
         }
     }

--- a/sfdx-source/core/main/classes/framework-test-data-supplementer/TestDataSupplementer.cls
+++ b/sfdx-source/core/main/classes/framework-test-data-supplementer/TestDataSupplementer.cls
@@ -56,7 +56,7 @@ public class TestDataSupplementer
     {
         if (sobjectList != null && !sobjectList.isEmpty())
         {
-            //now that supplement is called from ApplicationSObjectDomain
+            //Now that supplement is called from ApplicationSObjectDomain,
             //a supplement might not exist for every object type would result in an eror
             //check that ObjectType exists in the map before doing the look
             If (supplementerMap.containsKey(sobjectList.getSObjectType())) {


### PR DESCRIPTION
…main.

proposed solution:
Fixes #33 

supplement would no longer need to be called explicitly during tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/at4dx/35)
<!-- Reviewable:end -->
