### PR TITLE
Bugfixes for CMDT record queries during multiple calls in same thread

### DIFF
--- a/sfdx-source/core/main/classes/framework-application-factory/ApplicationSObjectDomainDIModule.cls
+++ b/sfdx-source/core/main/classes/framework-application-factory/ApplicationSObjectDomainDIModule.cls
@@ -34,12 +34,11 @@ public class ApplicationSObjectDomainDIModule
     @TestVisible
     private static list<ApplicationFactory_DomainBinding__mdt> bindingRecords = new list<ApplicationFactory_DomainBinding__mdt>();
 
-    private list<ApplicationFactory_DomainBinding__mdt> getBindingRecords()
+    static
     {
         bindingRecords.addAll([select DeveloperName, QualifiedAPIName, To__c
                                         , BindingSObject__c, BindingSObject__r.QualifiedApiName, BindingSObjectAlternate__c
                                     from ApplicationFactory_DomainBinding__mdt]);
-        return bindingRecords;
     }
 
     public override void configure() 
@@ -48,7 +47,7 @@ public class ApplicationSObjectDomainDIModule
 
         String bindingSObjectAPIName = null;
 
-        for ( ApplicationFactory_DomainBinding__mdt bindingConfig : getBindingRecords())
+        for ( ApplicationFactory_DomainBinding__mdt bindingConfig : bindingRecords )
         {
             bindingSObjectAPIName = String.isNotBlank(bindingConfig.BindingSObject__c) ? bindingConfig.BindingSObject__r.QualifiedApiName : bindingConfig.BindingSObjectAlternate__c;
 

--- a/sfdx-source/core/main/classes/framework-application-factory/ApplicationSObjectSelectorDIModule.cls
+++ b/sfdx-source/core/main/classes/framework-application-factory/ApplicationSObjectSelectorDIModule.cls
@@ -34,13 +34,12 @@ public class ApplicationSObjectSelectorDIModule
     @TestVisible
     private static List<ApplicationFactory_SelectorBinding__mdt> bindingRecords = new List<ApplicationFactory_SelectorBinding__mdt>();
 
-    private static List<ApplicationFactory_SelectorBinding__mdt> getBindingRecords()
+    static
     {
         bindingRecords.addAll(
             [select DeveloperName, QualifiedAPIName, To__c, BindingSObject__c, BindingSObject__r.QualifiedApiName, BindingSObjectAlternate__c
             from ApplicationFactory_SelectorBinding__mdt]
         );
-        return bindingRecords;
     }
 
     public override void configure() 
@@ -49,7 +48,7 @@ public class ApplicationSObjectSelectorDIModule
 
         String bindingSObjectAPIName = null;
 
-        for ( ApplicationFactory_SelectorBinding__mdt bindingConfig : getBindingRecords())
+        for ( ApplicationFactory_SelectorBinding__mdt bindingConfig : bindingRecords )
         {
             bindingSObjectAPIName = String.isNotBlank(bindingConfig.BindingSObject__c) ? bindingConfig.BindingSObject__r.QualifiedApiName : bindingConfig.BindingSObjectAlternate__c;
 

--- a/sfdx-source/core/main/classes/framework-application-factory/ApplicationSObjectUnitOfWorkDIProvider.cls
+++ b/sfdx-source/core/main/classes/framework-application-factory/ApplicationSObjectUnitOfWorkDIProvider.cls
@@ -23,25 +23,23 @@
  *  OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 **/
-
 public class ApplicationSObjectUnitOfWorkDIProvider 
     implements di_Binding.Provider
 {
-    private fflib_SObjectUnitOfWork.IDML dmlParam = null;
-    private List<Schema.SObjectType> sObjTypesParam = null;
-
     @TestVisible
     private static List<ApplicationFactory_UnitOfWorkBinding__mdt> bindingRecords = new List<ApplicationFactory_UnitOfWorkBinding__mdt>();
 
-    private static List<ApplicationFactory_UnitOfWorkBinding__mdt> getBindingRecords()
+    static 
     {
         bindingRecords.addAll([select DeveloperName, QualifiedAPIName, BindingSequence__c
-                                    , BindingSObject__c, BindingSObject__r.QualifiedApiName, BindingSObjectAlternate__c
-                                from ApplicationFactory_UnitOfWorkBinding__mdt
-                                order by BindingSequence__c]
-                            );
-        return bindingRecords;
+                                        , BindingSObject__c, BindingSObject__r.QualifiedApiName, BindingSObjectAlternate__c
+                                    from ApplicationFactory_UnitOfWorkBinding__mdt
+                                    order by BindingSequence__c]
+                                );
     }
+
+    private fflib_SObjectUnitOfWork.IDML dmlParam = null;
+    private List<Schema.SObjectType> sObjTypesParam = null;
 
     private void parseParamType(Object param)
     {
@@ -96,7 +94,7 @@ public class ApplicationSObjectUnitOfWorkDIProvider
 
             String bindingSObjectAPIName = null;
 
-            for ( ApplicationFactory_UnitOfWorkBinding__mdt bindingConfig : getBindingRecords())
+            for ( ApplicationFactory_UnitOfWorkBinding__mdt bindingConfig : bindingRecords)
             {
                 bindingSObjectAPIName = String.isNotBlank(bindingConfig.BindingSObject__c) ? bindingConfig.BindingSObject__r.QualifiedApiName : bindingConfig.BindingSObjectAlternate__c;
 

--- a/sfdx-source/core/main/classes/framework-application-factory/ApplicationSelectorFieldsetDIModule.cls
+++ b/sfdx-source/core/main/classes/framework-application-factory/ApplicationSelectorFieldsetDIModule.cls
@@ -32,7 +32,7 @@ public class ApplicationSelectorFieldsetDIModule
     @TestVisible
     private static List<SelectorConfig_FieldSetInclusion__mdt> bindingRecords = new List<SelectorConfig_FieldSetInclusion__mdt>();
 
-    private static List<SelectorConfig_FieldSetInclusion__mdt> getBindingRecords()
+    static
     {
         bindingRecords.addAll
         ([
@@ -42,7 +42,6 @@ public class ApplicationSelectorFieldsetDIModule
             from SelectorConfig_FieldSetInclusion__mdt
             where IsActive__c = true
         ]);
-        return bindingRecords;
     }
 
     public override void configure() 
@@ -55,7 +54,7 @@ public class ApplicationSelectorFieldsetDIModule
 
         String bindingSObjectAPIName = null;
 
-        for (SelectorConfig_FieldSetInclusion__mdt scfi : getBindingRecords())
+        for (SelectorConfig_FieldSetInclusion__mdt scfi : bindingRecords)
         {
             bindingSObjectAPIName = String.isNotBlank(scfi.BindingSObject__c) ? scfi.BindingSObject__r.QualifiedApiName : scfi.BindingSObjectAlternate__c; 
 

--- a/sfdx-source/core/main/classes/framework-application-factory/ApplicationServiceDIModule.cls
+++ b/sfdx-source/core/main/classes/framework-application-factory/ApplicationServiceDIModule.cls
@@ -34,15 +34,14 @@ public class ApplicationServiceDIModule
     @TestVisible
     private static List<ApplicationFactory_ServiceBinding__mdt> bindingRecords = new List<ApplicationFactory_ServiceBinding__mdt>();
 
-    private static List<ApplicationFactory_ServiceBinding__mdt> getBindingRecords()
+    static
     {
         bindingRecords.addAll([select DeveloperName, QualifiedAPIName, To__c, BindingInterface__c from ApplicationFactory_ServiceBinding__mdt]);
-        return bindingRecords;
     }
 
     public override void configure() 
     {
-        for ( ApplicationFactory_ServiceBinding__mdt bindingConfig : getBindingRecords())
+        for ( ApplicationFactory_ServiceBinding__mdt bindingConfig : bindingRecords )
         {
             apex();
             try {

--- a/sfdx-source/core/main/classes/framework-platform-event-distributor/PlatformEventDistributor.cls
+++ b/sfdx-source/core/main/classes/framework-platform-event-distributor/PlatformEventDistributor.cls
@@ -37,6 +37,24 @@ public class PlatformEventDistributor
     private static string CATEGORY_FIELD_NAME = 'Category__c'.toLowerCase();
     private static string EVENT_NAME_FIELD_NAME = 'EventName__c'.toLowerCase();
 
+    @TestVisible
+    private static List<PlatformEvents_Subscription__mdt> registeredSubscribers = new List<PlatformEvents_Subscription__mdt>();
+
+    private static List<PlatformEvents_Subscription__mdt> getRegisteredSubscribers(String eventBus)
+    {
+        if (String.isBlank(eventBus))
+        {
+            throw new PlatformEventDistributorException('eventBus parameter is required');
+        }
+
+        registeredSubscribers.addAll([select Consumer__c, EventCategory__c, Event__c, IsActive__c, MatcherRule__c, EventBus__c, Execute_Synchronous__c
+                                        from PlatformEvents_Subscription__mdt
+                                       where IsActive__c = true
+                                         and EventBus__c = :eventBus]); 
+
+        return registeredSubscribers;
+    }
+
     private Map<String, List<PlatformEvents_Subscription__mdt>> eventBusToConfigurationMap = new Map<String, List<PlatformEvents_Subscription__mdt>>();
 
     @TestVisible
@@ -223,24 +241,6 @@ public class PlatformEventDistributor
         }
 
         return result;
-    }
-
-    @TestVisible
-    private static List<PlatformEvents_Subscription__mdt> registeredSubscribers = new List<PlatformEvents_Subscription__mdt>();
-
-    private static List<PlatformEvents_Subscription__mdt> getRegisteredSubscribers(String eventBus)
-    {
-        if (String.isBlank(eventBus))
-        {
-            throw new PlatformEventDistributorException('eventBus parameter is required');
-        }
-
-        registeredSubscribers.addAll([select Consumer__c, EventCategory__c, Event__c, IsActive__c, MatcherRule__c, EventBus__c, Execute_Synchronous__c
-                                        from PlatformEvents_Subscription__mdt
-                                       where IsActive__c = true
-                                         and EventBus__c = :eventBus]); 
-
-        return registeredSubscribers;
     }
 
     public class PlatformEventDistributorException

--- a/sfdx-source/core/main/classes/framework-platform-event-distributor/PlatformEventDistributorDIModule.cls
+++ b/sfdx-source/core/main/classes/framework-platform-event-distributor/PlatformEventDistributorDIModule.cls
@@ -27,11 +27,22 @@
 public class PlatformEventDistributorDIModule
     extends di_Module
 {
+    @TestVisible
+    private static List<PlatformEvents_Subscription__mdt> registeredSubscribers = new List<PlatformEvents_Subscription__mdt>();
+
+    static
+    {
+        registeredSubscribers.addAll([select DeveloperName, Consumer__c, Event__c , EventCategory__c
+                                         , MatcherRule__c, EventBus__c, Execute_Synchronous__c
+                                      from PlatformEvents_Subscription__mdt 
+                                     where IsActive__c = true]);
+    }
+
     public override void configure()
     {
         String warningMessage = '';
 
-        for ( PlatformEvents_Subscription__mdt registeredSubscriber : getRegisteredSubscribers())
+        for ( PlatformEvents_Subscription__mdt registeredSubscriber : registeredSubscribers)
         {
             warningMessage = '';
             
@@ -64,18 +75,5 @@ public class PlatformEventDistributorDIModule
             data(registeredSubscriber);
             to(registeredSubscriber.Consumer__c);       
         } 
-    }
-
-    @TestVisible
-    private static List<PlatformEvents_Subscription__mdt> registeredSubscribers = new List<PlatformEvents_Subscription__mdt>();
-
-    private List<PlatformEvents_Subscription__mdt> getRegisteredSubscribers()
-    {
-        registeredSubscribers.addAll([select DeveloperName, Consumer__c, Event__c , EventCategory__c
-                                         , MatcherRule__c, EventBus__c, Execute_Synchronous__c
-                                      from PlatformEvents_Subscription__mdt 
-                                     where IsActive__c = true]);
-
-        return registeredSubscribers;
     }
 }


### PR DESCRIPTION
Changes made:
* Moved querying of CMDT binding records over to static initialization methods to avoid multiple calls to the query method if the class were called multiple times in the same thread.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/at4dx/50)
<!-- Reviewable:end -->
