### PR TITLE
Minor adjustments to tests

### DIFF
--- a/sfdx-source/core/test/classes/framework-application-factory/ApplicationFactoryTest.cls
+++ b/sfdx-source/core/test/classes/framework-application-factory/ApplicationFactoryTest.cls
@@ -115,6 +115,10 @@ private class ApplicationFactoryTest
         };
 
         ApplicationSObjectSelectorDIModule.bindingRecords.addAll(bindingList);
+
+        // override the selector bindings just in case this method
+        //  executes in an org that already has an AccountsSelector.
+        Application.Selector.setMock(new TestAccountsSelector());
     }
 
     /********************************************************

--- a/sfdx-source/core/test/classes/framework-application-factory/ApplicationSObjectSelectorTest.cls
+++ b/sfdx-source/core/test/classes/framework-application-factory/ApplicationSObjectSelectorTest.cls
@@ -71,6 +71,10 @@ private class ApplicationSObjectSelectorTest
         };
 
         ApplicationSObjectSelectorDIModule.bindingRecords.addAll(bindingList);
+
+        // override the selector bindings just in case this method
+        //  executes in an org that already has an AccountsSelector.
+        Application.Selector.setMock(new TestAccountsSelector());
     }
 
     public class TestSelectorMethod


### PR DESCRIPTION
Changes made:
* Added quick call to override the default binding for an AccountsSelector just in case there is already an AccountsSelector present in the org.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/at4dx/51)
<!-- Reviewable:end -->
