### PR TITLE
Add Immediate Publish Event

### DIFF
--- a/sfdx-source/core/main/schema/objects/AT4DXImmediateMessage__e/AT4DXImmediateMessage__e.object-meta.xml
+++ b/sfdx-source/core/main/schema/objects/AT4DXImmediateMessage__e/AT4DXImmediateMessage__e.object-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <deploymentStatus>Deployed</deploymentStatus>
+    <description>The high volume platform event bus for managing immediately published AT4DX messages the org.</description>
+    <eventType>HighVolume</eventType>
+    <label>AT4DX Immediate Message</label>
+    <pluralLabel>AT4DX Immediate Messages</pluralLabel>
+    <publishBehavior>PublishImmediately</publishBehavior>
+</CustomObject>

--- a/sfdx-source/core/main/schema/objects/AT4DXImmediateMessage__e/fields/Category__c.field-meta.xml
+++ b/sfdx-source/core/main/schema/objects/AT4DXImmediateMessage__e/fields/Category__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Category__c</fullName>
+    <description>Specifies a division of the universal bus, which enables more precise matching.  Normally this field will contain the SObject name related to the event, e.g. Account, Opportunity, etc.</description>
+    <externalId>false</externalId>
+    <isFilteringDisabled>false</isFilteringDisabled>
+    <isNameField>false</isNameField>
+    <isSortingDisabled>false</isSortingDisabled>
+    <label>Category</label>
+    <length>255</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/sfdx-source/core/main/schema/objects/AT4DXImmediateMessage__e/fields/EventName__c.field-meta.xml
+++ b/sfdx-source/core/main/schema/objects/AT4DXImmediateMessage__e/fields/EventName__c.field-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>EventName__c</fullName>
+    <description>The name of the event, which correlates the Bus Name.</description>
+    <externalId>false</externalId>
+    <isFilteringDisabled>false</isFilteringDisabled>
+    <isNameField>false</isNameField>
+    <isSortingDisabled>false</isSortingDisabled>
+    <label>Event Name</label>
+    <length>255</length>
+    <required>true</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/sfdx-source/core/main/schema/objects/AT4DXImmediateMessage__e/fields/Payload__c.field-meta.xml
+++ b/sfdx-source/core/main/schema/objects/AT4DXImmediateMessage__e/fields/Payload__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Payload__c</fullName>
+    <description>The JSON payload encapsulating all of the information for the event.</description>
+    <externalId>false</externalId>
+    <isFilteringDisabled>false</isFilteringDisabled>
+    <isNameField>false</isNameField>
+    <isSortingDisabled>false</isSortingDisabled>
+    <label>Payload</label>
+    <length>131072</length>
+    <type>LongTextArea</type>
+    <visibleLines>3</visibleLines>
+</CustomField>

--- a/sfdx-source/core/main/triggers/AT4DXImmediateMessages.trigger
+++ b/sfdx-source/core/main/triggers/AT4DXImmediateMessages.trigger
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2020, John M. Daniel & John Storey
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, 
+ *   are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, 
+ *      this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice, 
+ *      this list of conditions and the following disclaimer in the documentation 
+ *      and/or other materials provided with the distribution.
+ * - Neither the name of the John M. Daniel, nor the names of its contributors 
+ *      may be used to endorse or promote products derived from this software without 
+ *      specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES 
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL 
+ *  THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, 
+ *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ *  OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ *  OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**/
+
+trigger AT4DXImmediateMessages on AT4DXImmediateMessage__e 
+    (after insert) 
+{
+    PlatformEventDistributor.triggerHandler();
+}

--- a/sfdx-source/core/main/triggers/AT4DXImmediateMessages.trigger-meta.xml
+++ b/sfdx-source/core/main/triggers/AT4DXImmediateMessages.trigger-meta.xml
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata" fqn="PlatformEvents">
+  <apiVersion>49.0</apiVersion>
+  <status>Active</status>
+</ApexTrigger>

--- a/sfdx-source/core/test/classes/framework-platform-event-distributor/PlatformEventDistributorTest.cls
+++ b/sfdx-source/core/test/classes/framework-platform-event-distributor/PlatformEventDistributorTest.cls
@@ -47,6 +47,26 @@ public class PlatformEventDistributorTest
         System.assertEquals(true, sr.isSuccess());
     }
 
+    @isTest
+    private static void basicTestToActivateCodeCoverageImmediate() 
+    {
+        AT4DXImmediateMessage__e platformEventbus = new AT4DXImmediateMessage__e();
+        platformEventbus.EventName__c = 'bluefish';
+        platformEventbus.Category__c = Account.getSObjectType().getDescribe().getName();
+        platformEventbus.Payload__c = json.serialize( new Set<Id>{ fflib_IDGenerator.generate(Account.SObjectType ) } );
+
+        Test.startTest();
+        Database.SaveResult sr = EventBus.publish(platformEventbus);
+
+        Integer initialSubscriberPosition = getCurrentEventBusSubscriberPosition();
+        
+        Test.stopTest();
+
+        System.assert( initialSubscriberPosition < getCurrentImmediateEventBusSubscriberPosition(), 'The current event bus subscriber position did not change.  This indicates that the Apex Platform event subscriber trigger did not activate.' );
+
+        System.assertEquals(true, sr.isSuccess());
+    }
+
     @IsTest
     private static void platformEventSubscriberTest()
     {
@@ -91,6 +111,19 @@ public class PlatformEventDistributorTest
         System.assert(at4dxMessageBusSubscriber != null, 'Could not find the ' + AT4DXMessage__e.SobjectType + ' record');
 
         return at4dxMessageBusSubscriber.Position;
+    }
+
+    private static Integer getCurrentImmediateEventBusSubscriberPosition()
+    {
+        EventBusSubscriber at4dxImmediateMessageBusSubscriber = [SELECT Id, ExternalId, Name, Type, Topic, Position, Tip, Retries, LastError, Status 
+                                                          FROM EventBusSubscriber 
+                                                         WHERE Topic = :AT4DXImmediateMessage__e.SobjectType.getDescribe().getName()
+                                                           AND Type = 'ApexTrigger'
+                                                         LIMIT 1];
+        
+        System.assert(at4dxImmediateMessageBusSubscriber != null, 'Could not find the ' + AT4DXImmediateMessage__e.SobjectType + ' record');
+
+        return at4dxImmediateMessageBusSubscriber.Position;
     }
 
     public static Boolean wasTestPlatformEventsConsumerCalled2 = false;


### PR DESCRIPTION
This adds an AT4DX Message that is of type PublishImmediately to facilitate use cases where the Platform Event needs to be published to the bus regardless of the current transaction committing successfully.