### PR TITLE
UPDATE: apiVersion to 53.0 to support post apiVersion 46.0 objects

### DIFF
--- a/sfdx-source/core/main/classes/framework-application-factory/Application.cls-meta.xml
+++ b/sfdx-source/core/main/classes/framework-application-factory/Application.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="Application">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/main/classes/framework-application-factory/ApplicationSObjectDomain.cls-meta.xml
+++ b/sfdx-source/core/main/classes/framework-application-factory/ApplicationSObjectDomain.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="ApplicationSObjectDomain">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/main/classes/framework-application-factory/ApplicationSObjectDomainDIModule.cls-meta.xml
+++ b/sfdx-source/core/main/classes/framework-application-factory/ApplicationSObjectDomainDIModule.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="ApplicationSObjectDomainDIModule">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/main/classes/framework-application-factory/ApplicationSObjectSelector.cls-meta.xml
+++ b/sfdx-source/core/main/classes/framework-application-factory/ApplicationSObjectSelector.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="ApplicationSObjectSelector">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/main/classes/framework-application-factory/ApplicationSObjectSelectorDIModule.cls-meta.xml
+++ b/sfdx-source/core/main/classes/framework-application-factory/ApplicationSObjectSelectorDIModule.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="ApplicationSObjectSelectorDIModule">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/main/classes/framework-application-factory/ApplicationSObjectUnitOfWork.cls-meta.xml
+++ b/sfdx-source/core/main/classes/framework-application-factory/ApplicationSObjectUnitOfWork.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="ApplicationSObjectUnitOfWork">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/main/classes/framework-application-factory/ApplicationSObjectUnitOfWorkDIModule.cls-meta.xml
+++ b/sfdx-source/core/main/classes/framework-application-factory/ApplicationSObjectUnitOfWorkDIModule.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="ApplicationSObjectUnitOfWorkDIModule">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/main/classes/framework-application-factory/ApplicationSObjectUnitOfWorkDIProvider.cls-meta.xml
+++ b/sfdx-source/core/main/classes/framework-application-factory/ApplicationSObjectUnitOfWorkDIProvider.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="ApplicationSObjectUnitOfWorkDIProvider">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/main/classes/framework-application-factory/ApplicationSelectorFieldsetDIModule.cls-meta.xml
+++ b/sfdx-source/core/main/classes/framework-application-factory/ApplicationSelectorFieldsetDIModule.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="ApplicationSelectorFieldsetDIModule">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/main/classes/framework-application-factory/ApplicationServiceDIModule.cls-meta.xml
+++ b/sfdx-source/core/main/classes/framework-application-factory/ApplicationServiceDIModule.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="ApplicationServiceDIModule">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/main/classes/framework-application-factory/IApplicationSObjectDomain.cls-meta.xml
+++ b/sfdx-source/core/main/classes/framework-application-factory/IApplicationSObjectDomain.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="IApplicationSObjectDomain">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/main/classes/framework-application-factory/IApplicationSObjectSelector.cls-meta.xml
+++ b/sfdx-source/core/main/classes/framework-application-factory/IApplicationSObjectSelector.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="IApplicationSObjectSelector">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/main/classes/framework-application-factory/IApplicationSObjectUnitOfWork.cls-meta.xml
+++ b/sfdx-source/core/main/classes/framework-application-factory/IApplicationSObjectUnitOfWork.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="IApplicationSObjectUnitOfWork">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/main/classes/framework-domain-process-injection/DomainProcessAbstractAction.cls-meta.xml
+++ b/sfdx-source/core/main/classes/framework-domain-process-injection/DomainProcessAbstractAction.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="DomainProcessAbstractAction">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/main/classes/framework-domain-process-injection/DomainProcessConstants.cls-meta.xml
+++ b/sfdx-source/core/main/classes/framework-domain-process-injection/DomainProcessConstants.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="DomainProcessConstants">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/main/classes/framework-domain-process-injection/DomainProcessCoordinator.cls-meta.xml
+++ b/sfdx-source/core/main/classes/framework-domain-process-injection/DomainProcessCoordinator.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="DomainProcessCoordinator">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/main/classes/framework-domain-process-injection/DomainProcessInjectionDIModule.cls-meta.xml
+++ b/sfdx-source/core/main/classes/framework-domain-process-injection/DomainProcessInjectionDIModule.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="DomainProcessInjectionDIModule">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/main/classes/framework-domain-process-injection/IDomainLogicInjectionsParameterable.cls-meta.xml
+++ b/sfdx-source/core/main/classes/framework-domain-process-injection/IDomainLogicInjectionsParameterable.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>49.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/main/classes/framework-domain-process-injection/IDomainProcessAction.cls-meta.xml
+++ b/sfdx-source/core/main/classes/framework-domain-process-injection/IDomainProcessAction.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="IDomainProcessAction">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/main/classes/framework-domain-process-injection/IDomainProcessActionWithExistingRecs.cls-meta.xml
+++ b/sfdx-source/core/main/classes/framework-domain-process-injection/IDomainProcessActionWithExistingRecs.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="IDomainProcessCriteriaWithExistingRecs">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/main/classes/framework-domain-process-injection/IDomainProcessCoordinator.cls-meta.xml
+++ b/sfdx-source/core/main/classes/framework-domain-process-injection/IDomainProcessCoordinator.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="IDomainProcessCoordinator">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/main/classes/framework-domain-process-injection/IDomainProcessCriteria.cls-meta.xml
+++ b/sfdx-source/core/main/classes/framework-domain-process-injection/IDomainProcessCriteria.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="IDomainProcessCriteria">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/main/classes/framework-domain-process-injection/IDomainProcessCriteriaWithExistingRecs.cls-meta.xml
+++ b/sfdx-source/core/main/classes/framework-domain-process-injection/IDomainProcessCriteriaWithExistingRecs.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="IDomainProcessCriteriaWithExistingRecs">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/main/classes/framework-domain-process-injection/IDomainProcessQueueableAction.cls-meta.xml
+++ b/sfdx-source/core/main/classes/framework-domain-process-injection/IDomainProcessQueueableAction.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="IDomainProcessQueueableAction">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/main/classes/framework-domain-process-injection/IDomainProcessUnitOfWorkable.cls-meta.xml
+++ b/sfdx-source/core/main/classes/framework-domain-process-injection/IDomainProcessUnitOfWorkable.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="IDomainProcessUnitOfWorkable">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/main/classes/framework-domain-process-injection/IDomainProcessWithParamsAction.cls-meta.xml
+++ b/sfdx-source/core/main/classes/framework-domain-process-injection/IDomainProcessWithParamsAction.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>49.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/main/classes/framework-domain-process-injection/IDomainProcessWithParamsCriteria.cls-meta.xml
+++ b/sfdx-source/core/main/classes/framework-domain-process-injection/IDomainProcessWithParamsCriteria.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>49.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/main/classes/framework-platform-event-distributor/IEventsConsumer.cls-meta.xml
+++ b/sfdx-source/core/main/classes/framework-platform-event-distributor/IEventsConsumer.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="IEventsConsumer">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/main/classes/framework-platform-event-distributor/PlatformEventAbstractConsumer.cls-meta.xml
+++ b/sfdx-source/core/main/classes/framework-platform-event-distributor/PlatformEventAbstractConsumer.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="PlatformEventAbstractConsumer">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/main/classes/framework-platform-event-distributor/PlatformEventDistributor.cls-meta.xml
+++ b/sfdx-source/core/main/classes/framework-platform-event-distributor/PlatformEventDistributor.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="PlatformEventDistributor">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/main/classes/framework-platform-event-distributor/PlatformEventDistributorDIModule.cls-meta.xml
+++ b/sfdx-source/core/main/classes/framework-platform-event-distributor/PlatformEventDistributorDIModule.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="PlatformEventDistributorDIModule">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/main/classes/framework-selector-method-injection/AbstractSelectorMethodInjectable.cls-meta.xml
+++ b/sfdx-source/core/main/classes/framework-selector-method-injection/AbstractSelectorMethodInjectable.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="AbstractSelectorMethodInjectable">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/main/classes/framework-selector-method-injection/ISelectorMethodInjectable.cls-meta.xml
+++ b/sfdx-source/core/main/classes/framework-selector-method-injection/ISelectorMethodInjectable.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="ISelectorMethodInjectable">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/main/classes/framework-selector-method-injection/ISelectorMethodParameterable.cls-meta.xml
+++ b/sfdx-source/core/main/classes/framework-selector-method-injection/ISelectorMethodParameterable.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="ISelectorMethodParameterable">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/main/classes/framework-selector-method-injection/ISelectorMethodSetable.cls-meta.xml
+++ b/sfdx-source/core/main/classes/framework-selector-method-injection/ISelectorMethodSetable.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="ISelectorMethodSetable">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/main/classes/framework-test-data-supplementer/ITestDataSupplement.cls-meta.xml
+++ b/sfdx-source/core/main/classes/framework-test-data-supplementer/ITestDataSupplement.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="ITestDataSupplement">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/main/classes/framework-test-data-supplementer/TestDataSupplementDIModule.cls-meta.xml
+++ b/sfdx-source/core/main/classes/framework-test-data-supplementer/TestDataSupplementDIModule.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="TestDataSupplementDIModule">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/main/classes/framework-test-data-supplementer/TestDataSupplementer.cls-meta.xml
+++ b/sfdx-source/core/main/classes/framework-test-data-supplementer/TestDataSupplementer.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="TestDataSupplementer">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/main/triggers/AT4DXImmediateMessages.trigger-meta.xml
+++ b/sfdx-source/core/main/triggers/AT4DXImmediateMessages.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata" fqn="PlatformEvents">
-  <apiVersion>49.0</apiVersion>
+  <apiVersion>53.0</apiVersion>
   <status>Active</status>
 </ApexTrigger>

--- a/sfdx-source/core/main/triggers/AT4DXMessages.trigger-meta.xml
+++ b/sfdx-source/core/main/triggers/AT4DXMessages.trigger-meta.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata" fqn="PlatformEvents">
-  <apiVersion>49.0</apiVersion>
+  <apiVersion>53.0</apiVersion>
   <status>Active</status>
 </ApexTrigger>

--- a/sfdx-source/core/test/classes/framework-application-factory/ApplicationFactoryTest.cls-meta.xml
+++ b/sfdx-source/core/test/classes/framework-application-factory/ApplicationFactoryTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/test/classes/framework-application-factory/ApplicationSObjectSelectorTest.cls-meta.xml
+++ b/sfdx-source/core/test/classes/framework-application-factory/ApplicationSObjectSelectorTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/test/classes/framework-application-factory/ApplicationSObjectUnitOfWorkTest.cls-meta.xml
+++ b/sfdx-source/core/test/classes/framework-application-factory/ApplicationSObjectUnitOfWorkTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>51.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/test/classes/framework-domain-process-injection/DomainProcessInjectionTest.cls-meta.xml
+++ b/sfdx-source/core/test/classes/framework-domain-process-injection/DomainProcessInjectionTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/test/classes/framework-platform-event-distributor/PlatformEventDistributorDIModuleTest.cls-meta.xml
+++ b/sfdx-source/core/test/classes/framework-platform-event-distributor/PlatformEventDistributorDIModuleTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>51.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/test/classes/framework-platform-event-distributor/PlatformEventDistributorTest.cls-meta.xml
+++ b/sfdx-source/core/test/classes/framework-platform-event-distributor/PlatformEventDistributorTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="PlatformEventDistributorTest">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/sfdx-source/core/test/classes/framework-selector-method-injection/AbstractSelectorMethodInjectableTest.cls-meta.xml
+++ b/sfdx-source/core/test/classes/framework-selector-method-injection/AbstractSelectorMethodInjectableTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>51.0</apiVersion>
+    <apiVersion>53.0</apiVersion>
     <status>Active</status>
 </ApexClass>


### PR DESCRIPTION
I struggled to figure out why `Application.{BindingName}.newInstance(Expense.SObjectType)` couldn't find my SObjectBinding for Expense.  After much troubleshooting, I found that the Field Service's Expense object wasn't introduced until apiVersion 49.0.  Updating the at4dx apiVersion to 53.0 fixed the issue.

### Changes
- Update all apiVersions to 53.0 to accommodate objects introduced after
  46.0.  Using older apiVersions where an object isn't yet supported can cause force-di to not find the SObjectBindings.
    - i.e. Field Service's Expense object was introduced in 49.0