### PR TITLE
Issue #79 - Fix NRE in TestSupplementer

### DIFF
--- a/sfdx-source/core/main/classes/framework-test-data-supplementer/TestDataSupplementer.cls
+++ b/sfdx-source/core/main/classes/framework-test-data-supplementer/TestDataSupplementer.cls
@@ -54,7 +54,7 @@ public class TestDataSupplementer
 
     public static void supplement(List<SObject> sobjectList)
     {
-        if (sobjectList != null && !sobjectList.isEmpty())
+        if (sobjectList != null && !sobjectList.isEmpty() && supplementerMap.containsKey(sobjectList.getSObjectType()))
         {
             for (ITestDataSupplement supplementer : supplementerMap.get(sobjectList.getSObjectType()))
             {


### PR DESCRIPTION
When supplementing logic does not exist for a SObjectType, the related map returns null.

Ref. Issue #79

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/at4dx/80)
<!-- Reviewable:end -->
