### PR TITLE
IApplicationSObjectSelector declare selectQueryLocatorInjection

### DIFF
--- a/sfdx-source/core/main/classes/framework-application-factory/IApplicationSObjectSelector.cls
+++ b/sfdx-source/core/main/classes/framework-application-factory/IApplicationSObjectSelector.cls
@@ -39,6 +39,11 @@ public interface IApplicationSObjectSelector
      * Selector Method Injection // executes an injected method against a pre-existing selector
      */
     List<SObject> selectInjection( System.Type methodClazz, ISelectorMethodParameterable params );
+
+    /**
+     * Selector Method Injection // executes an injected method against a pre-existing selector
+     */
+    Database.QueryLocator selectQueryLocatorInjection( System.Type methodClazzType, ISelectorMethodParameterable params );
     
     /**
      * Adds specified fields to the provided queryFactory preserving reference pathing.


### PR DESCRIPTION
method was added in #83 but is not usable with

```apex
Application.Selector.newInstance(Account.SObjectType).selectQueryLocatorInjection( {type of ISelectorQueryLocatorMethodInjectable}, ISelectorMethodParameterable )
``` 

as returning following error
```
Method does not exist or incorrect signature: void selectQueryLocatorInjection(System.Type, NULL) from the type IApplicationSObjectSelector
``` 

this PR intent to solve this

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/at4dx/84)
<!-- Reviewable:end -->
