### PR TITLE
Domain Process Coordinator - Execute Action Asynchronously when true

### DIFF
--- a/sfdx-source/core/main/classes/framework-domain-process-injection/DomainProcessCoordinator.cls
+++ b/sfdx-source/core/main/classes/framework-domain-process-injection/DomainProcessCoordinator.cls
@@ -441,7 +441,7 @@ public class DomainProcessCoordinator
                             actionClazz.setRecordsToActOn( qualifiedRecords );
 
                             // Should the action process execute in async/queueable mode?
-                            if (currentDomainProcess.ExecuteAsynchronous__c != null) {
+                            if (currentDomainProcess.ExecuteAsynchronous__c) {
                                 ((IDomainProcessQueueableAction)actionClazz).setActionToRunInQueue( currentDomainProcess.ExecuteAsynchronous__c );
                             }
                             

--- a/sfdx-source/core/main/classes/framework-domain-process-injection/DomainProcessCoordinator.cls
+++ b/sfdx-source/core/main/classes/framework-domain-process-injection/DomainProcessCoordinator.cls
@@ -441,7 +441,9 @@ public class DomainProcessCoordinator
                             actionClazz.setRecordsToActOn( qualifiedRecords );
 
                             // Should the action process execute in async/queueable mode?
-                            if (currentDomainProcess.ExecuteAsynchronous__c) {
+                            if (actionClazz instanceOf IDomainProcessQueueableAction
+                                && currentDomainProcess.ExecuteAsynchronous__c) 
+                            {
                                 ((IDomainProcessQueueableAction)actionClazz).setActionToRunInQueue( currentDomainProcess.ExecuteAsynchronous__c );
                             }
                             


### PR DESCRIPTION
Hi @ImJohnMDaniel,

Hope you're well! Might I propose this change? I recently ran into a use case when the `DomainProcessAbstractAction` that ships with the framework did not meet my requirements. The scope of my use case, however, was limited to the methods provided by `IDomainProcessAction` (I did not need to implement `IDomainProcessQueueableAction`).

So, in my action class, instead of extending `DomainProcessAbstractAction`, I just implemented `IDomainProcessAction`. When I did this, I ran into this issue with the `DomainProcessCoordinator`. Because the coordinator is checking whether `currentDomainProcess.ExecuteAsynchronous__c != null` (it will never be null since it is a boolean field), by proxy we must **always** implement `IDomainProcessQueueableAction`. If we switch the `if` to just check for if `ExecuteAsynchronous__c = true`, then we do not have to implement `IDomainProcessQueueableAction`.

Curious to know your thoughts on this,
Ryan

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apex-enterprise-patterns/at4dx/95)
<!-- Reviewable:end -->
